### PR TITLE
feat: user-service /api/couriers 라우팅 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,9 @@ spring:
             - id: user-service
               uri: lb://USER-SERVICE
               predicates:
-                - Path=/api/users/**, /internal/users/**, /api/couriers/**, /internal/couriers/**
+                - Path=/api/users/**, /api/couriers/**
+              # /internal/** 경로는 gateway 라우팅에서 제외 — 내부 Feign 호출은 Eureka로 직접 도달하며,
+              # gateway가 권한 검증 없이 통과시키면(permitAll) 외부 노출 시 보안 구멍이 됨.
 
             - id: order-service
               uri: lb://ORDER-SERVICE


### PR DESCRIPTION
## 📌 작업 유형
- [x] 라우팅 추가

## ✅ 작업 내용
user-service에 신규 추가된 4개 경로를 user-service 라우트에 매핑:
- \`/internal/users/**\` — delivery-service Feign 호출용 (User 단건/리스트)
- \`/api/couriers/**\` — MASTER admin Courier CRUD
- \`/internal/couriers/**\` — delivery-service Feign 호출용 (Courier 단건/배정 후보)

\`\`\`yaml
- id: user-service
  uri: lb://USER-SERVICE
  predicates:
    - Path=/api/users/**, /internal/users/**, /api/couriers/**, /internal/couriers/**
\`\`\`

## 🧪 테스트 / 확인 방법
- [x] 로컬 빌드 성공
- [ ] user-service PR 머지 후 통합 테스트

## ⚠️ 영향 범위
- [x] 라우팅 변경 (기존 \`/api/users/**\`는 그대로 유지, 3개 경로 추가)

## 🚨 보안 주의사항
- \`/internal/**\` 경로는 내부 서비스 호출 전용으로 권한 검증이 없음
- 운영 환경에서는 ALB Listener Rule 또는 Security Group으로 외부 트래픽 차단 필요
- 현재는 hub-service의 \`/internal/hub-inventories/**\`와 동일한 패턴 (운영 정책 일관성)

## 🤝 연관 작업
- user-service PR #4 (feat/internal-user-api): API 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 서비스 라우팅을 확장하여 사용자 및 배송원 관련 API 요청에 대한 경로 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->